### PR TITLE
Convert CPU frequency from MHz to GHz

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -442,7 +442,7 @@ const CPUFreqIndicator = new Lang.Class({
 	
 	_getCurFreq: function()
 	{
-		return this.cpufreq.toString() + 'MHz';
+		return (this.cpufreq.toString() / 1000).toFixed(2) + 'GHz';
 	},
 	
 	destroy: function()


### PR DESCRIPTION
Hi Martin,

The proposed change in this PR is kinda stylistic. As is, the CPU frequency is shown in MHz, which means that "810MHz" and "2154MHz" are both valid values. The problem is that, if there are more extensions on the left side of the widget, they'll be constantly moving to the left and right, since the number of characters in these values is not the same.

I propose showing the value in GHz and making it fixed to two decimal points, so that the above values become "0.81MHz" and "2.15GHz". I'm aware that the best option is to have a switch between GHz and MHz values, but I'm not familiar with the GUI aspect of this extension.

Finally, there's no problem if you don't like this change. It's just that I have it sitting on my branch for quite a while and decided to send it in case it seems useful.

Cheers,
Alex