### PR TITLE
Fix current frequency display & support Gnome 3.26

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,18 +1,11 @@
 {
 	"localedir":"/usr/local/share/locale",
 	"shell-version": [
-	"3.10",
-	"3.12",
-	"3.14",
-	"3.16",
-	"3.18",
-	"3.20",
-	"3.22",
-	"3.24"
-	], 
-	"uuid": "cpupower@mko-sl.de", 
+		"3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "3.22", "3.24", "3.26"
+	],
+	"uuid": "cpupower@mko-sl.de",
 	"name": "CPU Power Manager",
-	"url": "https://github.com/martin31821/cpupower", 
+	"url": "https://github.com/martin31821/cpupower",
 	"description": "Manage Intel_pstate CPU Frequency scaling driver",
 	"schema": "org.gnome.shell.extensions.cpupower"
 }

--- a/src/baseindicator.js
+++ b/src/baseindicator.js
@@ -41,7 +41,7 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.src.convenience;
 const SETTINGS_ID = 'org.gnome.shell.extensions.cpupower';
 
-const CPUFreqBaseIndicator = new Lang.Class({
+var CPUFreqBaseIndicator = new Lang.Class({
     Name: 'cpupower.CPUFreqBaseIndicator',
     Extends: PanelMenu.Button,
     Abstract: true,

--- a/src/indicator.js
+++ b/src/indicator.js
@@ -263,7 +263,7 @@ var CPUFreqIndicator = new Lang.Class({
     _updateFile: function()
     {
         let cmd = Math.floor(this.minVal) + '\n' + Math.floor(this.maxVal) + '\n' + (this.isTurboBoostActive ? 'true':'false') + '\n';
-		let path = EXTENSIONDIR + '/.last-settings';
+        let path = EXTENSIONDIR + '/.last-settings';
         GLib.file_set_contents(path, cmd);
     },
 
@@ -328,15 +328,15 @@ var CPUFreqIndicator = new Lang.Class({
             if(line.search(/cpu mhz/i) < 0)
                 continue;
 
-			let f = Shell.get_file_contents_utf8_sync('/sys/devices/system/cpu/cpu' + cpucount++ + '/cpufreq/scaling_cur_freq');
-			cpufreq += parseInt(f / 1024);
+            let f = Shell.get_file_contents_utf8_sync('/sys/devices/system/cpu/cpu' + cpucount++ + '/cpufreq/scaling_cur_freq');
+            cpufreq += parseInt(f / 1024);
         }
-		this.cpufreq = (cpufreq / cpucount)
-		this.imCurrentLabel.set_text(this._getCurFreq());
-		if(this.lblActive)
-			this.lbl.set_text(this._getCurFreq());
-		else
-			this.lbl.set_text('');
+        this.cpufreq = (cpufreq / cpucount)
+        this.imCurrentLabel.set_text(this._getCurFreq());
+        if(this.lblActive)
+            this.lbl.set_text(this._getCurFreq());
+        else
+            this.lbl.set_text('');
 
         return true;
     },

--- a/src/notinstalled.js
+++ b/src/notinstalled.js
@@ -41,7 +41,7 @@ const SETTINGS_ID = 'org.gnome.shell.extensions.cpupower';
 const Gettext = imports.gettext.domain('gnome-shell-extension-cpupower');
 const _ = Gettext.gettext;
 
-const NotInstalledIndicator = new Lang.Class({
+var NotInstalledIndicator = new Lang.Class({
     Name: 'cpupower.CPUFreqNotInstalledIndicator',
     Extends: CPUFreqBaseIndicator,
 

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -44,7 +44,7 @@ const EXTENSIONDIR = Me.dir.get_path();
 const GLADE_FILE = EXTENSIONDIR + "/data/cpupower-preferences.glade";
 const SETTINGS_SCHEMA = 'org.gnome.shell.extensions.cpupower';
 
-const CPUPowerPreferences = new Lang.Class({
+var CPUPowerPreferences = new Lang.Class({
     Name: 'cpupower.Preferences',
 
     _init: function()

--- a/src/profile.js
+++ b/src/profile.js
@@ -32,7 +32,7 @@ const GenerateUUID = function ()
     return Math.floor(1 + Math.random() * 0xFFFFFFFE).toString();
 };
 
-const CPUFreqProfile = new Lang.Class({
+var CPUFreqProfile = new Lang.Class({
     Name: 'cpupower.CPUFreqProfile',
 
     _init: function()

--- a/src/profilebutton.js
+++ b/src/profilebutton.js
@@ -32,7 +32,7 @@ const PopupMenu = imports.ui.popupMenu;
 
 const DEFAULT_EMPTY_NAME = 'No name';
 
-const CPUFreqProfileButton = new Lang.Class({
+var CPUFreqProfileButton = new Lang.Class({
     Name: 'cpupower.CPUFreqProfileButton',
     Extends: PopupMenu.PopupMenuItem,
 

--- a/src/unsupported.js
+++ b/src/unsupported.js
@@ -39,7 +39,7 @@ const Gettext = imports.gettext.domain('gnome-shell-extension-cpupower');
 const _ = Gettext.gettext;
 
 
-const UnsupportedIndicator = new Lang.Class({
+var UnsupportedIndicator = new Lang.Class({
     Name: 'cpupower.CPUFreqUnsupportedIndicator',
     Extends: CPUFreqBaseIndicator,
 


### PR DESCRIPTION
This adds support for Gnome 3.26 and also gets the current frequency average via reading `/sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq` (`/proc/cpuinfo` doesn't appear to update the CPU frequency anymore).