### PR TITLE
Tl/set governor on turbo state

### DIFF
--- a/src/cpufreqctl
+++ b/src/cpufreqctl
@@ -26,7 +26,7 @@ function log {
 }
 
 function err {
-	show_usage
+    show_usage
     echo "error: $@" >&2 && false
 }
 
@@ -46,17 +46,17 @@ function show_help {
     help_max
     help_examples
     help_copyright
-	exit
+    exit
 }
 
 function help_arguments {
-	log
+    log
     log "optional arguments:"
     log "    -h, --help   show this help message and exit"
 }
 
 function help_actions {
-	log
+    log
     log "available actions:"
     log "    turbo        control or read the turbo boost state of your cpu"
     log "    min          get or set the minimum cpu frequency (in %, [0;100])"
@@ -65,7 +65,7 @@ function help_actions {
 }
 
 function help_turbo {
-	log
+    log
     log "turbo parameters:"
     log "    get          get the current turbo boost state"
     log "    0            turn turbo boost off"
@@ -73,7 +73,7 @@ function help_turbo {
 }
 
 function help_min {
-	log
+    log
     log "min parameters:"
     log "    get          get the current set minimum frequency (in %, [0;100])"
     log "    check        get the smallest allowed minimum frequency for your cpu model"
@@ -83,14 +83,14 @@ function help_min {
 }
 
 function help_max {
-	log
+    log
     log "max parameters:"
     log "    get          get the current set maximum frequency (in %, [0;100])"
     log "    VALUE        set the current maximum frequency to a value in [0;100]"
 }
 
 function help_examples {
-	log
+    log
     log "examples:"
     log "    set the maximum frequency to 50%"
     log "        cpufreqctl max 50"
@@ -101,8 +101,8 @@ function help_examples {
 }
 
 function help_copyright {
-	log
-	log "cpufreqctl  Copyright (c) 2017-$(date '+%Y') Martin Koppehel, Fin Christensen"
+    log
+    log "cpufreqctl  Copyright (c) 2017-$(date '+%Y') Martin Koppehel, Fin Christensen"
 }
 
 if [ $# -lt 1 ]; then
@@ -122,13 +122,13 @@ case "$1" in
     if [ -z "$2" ]; then
         log "usage: cpufreqctl turbo {get,0,1}"
         help_turbo
-		help_copyright
+        help_copyright
     elif [ "$2" = "get" ]; then
         cat /sys/devices/system/cpu/intel_pstate/no_turbo
     elif [ "$2" -lt 0 ] || [ "$2" -gt 1 ]; then
         log "usage: cpufreqctl turbo {get,0,1}"
         err "VALUE must be 0 or 1"
-	else
+    else
         if [ "$2" -eq 1 ]; then
             policy="performance"
             echo 0 > /sys/devices/system/cpu/intel_pstate/no_turbo
@@ -142,30 +142,28 @@ case "$1" in
             echo "$policy" > "$governor"
         done
     fi
-	;;
-
+    ;;
 "max")
     if [ -z "$2" ]; then
         log "usage: cpufreqctl max {get,VALUE}"
         help_max
-		help_copyright
-	elif [ "$2" = "get" ]; then
+        help_copyright
+    elif [ "$2" = "get" ]; then
         cat /sys/devices/system/cpu/intel_pstate/max_perf_pct
-	elif [ "$2" -lt 0 ] || [ "$2" -gt 100 ]; then
+    elif [ "$2" -lt 0 ] || [ "$2" -gt 100 ]; then
         log "usage: cpufreqctl max {get,VALUE}"
-	    err "VALUE must be between 0 and 100"
-	else
-		echo "$2" > /sys/devices/system/cpu/intel_pstate/max_perf_pct
+        err "VALUE must be between 0 and 100"
+    else
+        echo "$2" > /sys/devices/system/cpu/intel_pstate/max_perf_pct
     fi
-	;;
-
+    ;;
 "min")
     if [ -z "$2" ]; then
         log "usage: cpufreqctl mini {get,check,VALUE}"
         help_min
-		help_copyright
+        help_copyright
     elif [ "$2" = "get" ]; then
-	    cat /sys/devices/system/cpu/intel_pstate/min_perf_pct
+        cat /sys/devices/system/cpu/intel_pstate/min_perf_pct
     elif [ "$2" = "check" ]; then
         preValue=$(</sys/devices/system/cpu/intel_pstate/min_perf_pct)
         echo 0 > /sys/devices/system/cpu/intel_pstate/min_perf_pct
@@ -174,11 +172,11 @@ case "$1" in
         echo "${postValue}"
     elif [ "$2" -lt 0 ] || [ "$2" -gt 100 ]; then
         log "usage: cpufreqctl min {get,check,VALUE}"
-	    err "VALUE must be between 0 and 100"
-	else
+        err "VALUE must be between 0 and 100"
+    else
         echo "$2" > /sys/devices/system/cpu/intel_pstate/min_perf_pct
     fi
-	;;
+    ;;
 *)
-	err "invalid option"
+    err "invalid option"
 esac

--- a/src/cpufreqctl
+++ b/src/cpufreqctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # cpufreqctl - This script can configure the pstate driver of your intel CPU.
 #
@@ -21,24 +21,24 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-set -e
-
-log ()
-{
+function log {
     echo "$@" >&2 || true
 }
 
-show_usage ()
-{
+function err {
+	show_usage
+    echo "error: $@" >&2 && false
+}
+
+function show_usage {
     log "usage: cpufreqctl [-h] [turbo {get,0,1}] [min {get,check,VALUE}] [max {get,VALUE}]"
 }
 
-show_help ()
-{
+function show_help {
     log "usage: cpufreqctl [-h] ACTION PARAMETER"
     log
     log "This script can configure the pstate driver of your intel CPU."
-    log
+
     help_arguments
     help_actions
     help_turbo
@@ -46,182 +46,139 @@ show_help ()
     help_max
     help_examples
     help_copyright
+	exit
 }
 
-help_arguments ()
-{
+function help_arguments {
+	log
     log "optional arguments:"
     log "    -h, --help   show this help message and exit"
-    log
 }
 
-help_actions ()
-{
+function help_actions {
+	log
     log "available actions:"
     log "    turbo        control or read the turbo boost state of your cpu"
     log "    min          get or set the minimum cpu frequency (in %, [0;100])"
     log "                 or get the smallest allowed value"
     log "    max          get or set the maximum cpu frequency (in %, [0;100])"
-    log
 }
 
-help_turbo ()
-{
+function help_turbo {
+	log
     log "turbo parameters:"
     log "    get          get the current turbo boost state"
     log "    0            turn turbo boost off"
     log "    1            turn turbo boost on"
-    log
 }
 
-help_min ()
-{
+function help_min {
+	log
     log "min parameters:"
     log "    get          get the current set minimum frequency (in %, [0;100])"
     log "    check        get the smallest allowed minimum frequency for your cpu model"
     log "    VALUE        set the current minimum frequency to a value in [0;100]"
     log "                 the values is automatically clamped to the minimum allowed cpu"
     log "                 frequency"
-    log
 }
 
-help_max ()
-{
+function help_max {
+	log
     log "max parameters:"
     log "    get          get the current set maximum frequency (in %, [0;100])"
     log "    VALUE        set the current maximum frequency to a value in [0;100]"
-    log
 }
 
-help_examples ()
-{
+function help_examples {
+	log
     log "examples:"
-    log "    Set the maximum frequency to 50%"
+    log "    set the maximum frequency to 50%"
     log "        cpufreqctl max 50"
-    log
-    log "    Get the turbo boost state"
+    log "    get the turbo boost state"
     log "        cpufreqctl turbo get"
-    log
-    log "    Get smallest allowed minimum cpu frequency for your model"
+    log "    get smallest allowed minimum cpu frequency for your model"
     log "        cpufreqctl min check"
-    log
 }
 
-help_copyright ()
-{
-    log "cpufreqctl  Copyright (c) 2017  Martin Koppehel, Fin Christensen"
+function help_copyright {
+	log
+	log "cpufreqctl  Copyright (c) 2017-$(date '+%Y') Martin Koppehel, Fin Christensen"
 }
 
-if [ $# -lt 1 ]
-then
-    show_usage
-    log "error: you must specify an action!"
-    exit
+if [ $# -lt 1 ]; then
+    err "you must specify an action!"
 fi
 
-if [ "$1" = "-h" ] || [ "$1" = "--help" ]
-then
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
     show_help
-    exit
 fi
 
-if [ "$1" = "turbo" ]
-then
-    if [ -z "$2" ]
-    then
+if [[ $EUID -ne 0 ]]; then
+    err "This script must be run as root!"
+fi
+
+case "$1" in
+"turbo")
+    if [ -z "$2" ]; then
         log "usage: cpufreqctl turbo {get,0,1}"
-        log
         help_turbo
-        help_copyright
-        exit
-    fi
-
-    if [ "$2" = "get" ]
-    then
-	value=$(<"/sys/devices/system/cpu/intel_pstate/no_turbo")
-	if [ "${value}" -eq 0 ]
-	then
-	    echo 1
-	else
-	    echo 0
-	fi
-	exit
-    fi
-    if [ "$2" -lt 0 ] || [ "$2" -gt 1 ];
-    then
+		help_copyright
+    elif [ "$2" = "get" ]; then
+        cat /sys/devices/system/cpu/intel_pstate/no_turbo
+    elif [ "$2" -lt 0 ] || [ "$2" -gt 1 ]; then
         log "usage: cpufreqctl turbo {get,0,1}"
-	log "error: VALUE must be 0 or 1"
-	exit
-    fi
+        err "VALUE must be 0 or 1"
+	else
+        if [ "$2" -eq 1 ]; then
+            policy="performance"
+            echo 0 > /sys/devices/system/cpu/intel_pstate/no_turbo
+        elif [ "$2" -eq 0 ]; then
+            policy="powersave"
+            echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo
+        fi
 
-    if [ "$2" -eq 1 ]
-    then
-	echo 0 > /sys/devices/system/cpu/intel_pstate/no_turbo
-    else
-	echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo
+        for governor in /sys/devices/system/cpu/cpufreq/policy*/scaling_governor
+        do
+            echo "$policy" > "$governor"
+        done
     fi
-    exit
-fi
+	;;
 
-if [ "$1" = "max" ]
-then
-    if [ -z "$2" ]
-    then
+"max")
+    if [ -z "$2" ]; then
         log "usage: cpufreqctl max {get,VALUE}"
-        log
         help_max
-        help_copyright
-        exit
-    fi
-
-    if [ "$2" = "get" ]
-    then
-	value=$(</sys/devices/system/cpu/intel_pstate/max_perf_pct)
-	echo "${value}"
-	exit
-    fi
-    if [ "$2" -lt 0 ] || [ "$2" -gt 100 ];
-    then
+		help_copyright
+	elif [ "$2" = "get" ]; then
+        cat /sys/devices/system/cpu/intel_pstate/max_perf_pct
+	elif [ "$2" -lt 0 ] || [ "$2" -gt 100 ]; then
         log "usage: cpufreqctl max {get,VALUE}"
-	log "error: VALUE must be between 0 and 100"
-	exit
+	    err "VALUE must be between 0 and 100"
+	else
+		echo "$2" > /sys/devices/system/cpu/intel_pstate/max_perf_pct
     fi
-    echo "$2" > /sys/devices/system/cpu/intel_pstate/max_perf_pct
-    exit
-fi
+	;;
 
-if [ "$1" = "min" ]
-then
-    if [ -z "$2" ]
-    then
+"min")
+    if [ -z "$2" ]; then
         log "usage: cpufreqctl mini {get,check,VALUE}"
-        log
         help_min
-        help_copyright
-        exit
-    fi
-
-    if [ "$2" = "get" ]
-    then
-	value=$(</sys/devices/system/cpu/intel_pstate/min_perf_pct)
-	echo "${value}"
-	exit
-    fi
-    if [ "$2" = "check" ]
-    then
-	preValue=$(</sys/devices/system/cpu/intel_pstate/min_perf_pct)
-	echo 0 > /sys/devices/system/cpu/intel_pstate/min_perf_pct
-	postValue=$(</sys/devices/system/cpu/intel_pstate/min_perf_pct)
-	echo "${preValue}" > /sys/devices/system/cpu/intel_pstate/min_perf_pct
-	echo "${postValue}"
-	exit
-    fi
-    if [ "$2" -lt 0 ] || [ "$2" -gt 100 ];
-    then
+		help_copyright
+    elif [ "$2" = "get" ]; then
+	    cat /sys/devices/system/cpu/intel_pstate/min_perf_pct
+    elif [ "$2" = "check" ]; then
+        preValue=$(</sys/devices/system/cpu/intel_pstate/min_perf_pct)
+        echo 0 > /sys/devices/system/cpu/intel_pstate/min_perf_pct
+        postValue=$(</sys/devices/system/cpu/intel_pstate/min_perf_pct)
+        echo "${preValue}" > /sys/devices/system/cpu/intel_pstate/min_perf_pct
+        echo "${postValue}"
+    elif [ "$2" -lt 0 ] || [ "$2" -gt 100 ]; then
         log "usage: cpufreqctl min {get,check,VALUE}"
-	log "error: VALUE must be between 0 and 100"
-	exit
+	    err "VALUE must be between 0 and 100"
+	else
+        echo "$2" > /sys/devices/system/cpu/intel_pstate/min_perf_pct
     fi
-    echo "$2" > /sys/devices/system/cpu/intel_pstate/min_perf_pct
-    exit
-fi
+	;;
+*)
+	err "invalid option"
+esac

--- a/src/cpufreqctl
+++ b/src/cpufreqctl
@@ -124,7 +124,8 @@ case "$1" in
         help_turbo
         help_copyright
     elif [ "$2" = "get" ]; then
-        cat /sys/devices/system/cpu/intel_pstate/no_turbo
+        value=$(<"/sys/devices/system/cpu/intel_pstate/no_turbo")
+        [ "${value}" -eq 0 ] && echo 1 || echo 0
     elif [ "$2" -lt 0 ] || [ "$2" -gt 1 ]; then
         log "usage: cpufreqctl turbo {get,0,1}"
         err "VALUE must be 0 or 1"


### PR DESCRIPTION
This will set the governor policy when switching turbo states:
```
➜ sudo ./src/cpufreqctl turbo get
0
➜ find /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor -exec cat {} + | uniq
powersave
➜ sudo ./src/cpufreqctl turbo 1
➜ sudo ./src/cpufreqctl turbo get
1
➜ find /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor -exec cat {} + | uniq
performance
```