### PR TITLE
[Bash] Fix missing 'max check' functionality

### DIFF
--- a/src/cpufreqctl
+++ b/src/cpufreqctl
@@ -180,6 +180,17 @@ then
 	echo "${value}"
 	exit
     fi
+
+    if [ "$2" = "check" ]
+    then
+	preValue=$(</sys/devices/system/cpu/intel_pstate/max_perf_pct)
+	echo 100 > /sys/devices/system/cpu/intel_pstate/max_perf_pct
+	postValue=$(</sys/devices/system/cpu/intel_pstate/max_perf_pct)
+	echo "${preValue}" > /sys/devices/system/cpu/intel_pstate/max_perf_pct
+	echo "${postValue}"
+	exit
+    fi
+
     if [ "$2" -lt 0 ] || [ "$2" -gt 100 ];
     then
         log "usage: cpufreqctl max {get,VALUE}"


### PR DESCRIPTION
I tried to use "cpufreqctl" as a standalone script (From `master` branch), but when I invoked it with "max check" options, it printed the following error:

```sh

./cpufreqctl: line 183: [: check: an entire expression was expected
./cpufreqctl: line 183: [: check: an entire expression was expected
./cpufreqctl: line 189: echo: writing error: Invalid argument
```

Although I'm not aware of any more cases of this bug, here's my little contribution to this simple issue.