### PR TITLE
Remove expand icon next to cpu icon

### DIFF
--- a/src/baseindicator.js
+++ b/src/baseindicator.js
@@ -66,7 +66,6 @@ var CPUFreqBaseIndicator = class CPUFreqBaseIndicator {
         this.lblUnit = (this.settings.get_boolean('taskbar-freq-unit-ghz'));
 
         this.hbox.add_actor(icon);
-        this.hbox.add_actor(PopupMenu.arrowIcon(St.Side.BOTTOM));
 
 
         this.settings.connect('changed', () => this.createMenu());

--- a/src/baseindicator.js
+++ b/src/baseindicator.js
@@ -84,7 +84,10 @@ var CPUFreqBaseIndicator = class CPUFreqBaseIndicator {
     enable() {
         this.actor.add_actor(this.hbox);
     }
+
     destroy() {
         this._mainButton.destroy();
     }
+
 }
+


### PR DESCRIPTION
The expand icon which is currently present is unnecessary since all gnome top menu items are expandable anyway. This made the icon unnecessary and cluttering.  It looks better without it too -- more compact and to the point.  I hope you accept it:

![image](https://user-images.githubusercontent.com/7459151/66524885-fdf2a180-eaf3-11e9-8ad8-2eb39810e8d3.png)
