### PR TITLE
Replace `setValue()` with `Slider.value`, fix #88

### DIFF
--- a/src/indicator.js
+++ b/src/indicator.js
@@ -251,10 +251,10 @@ var CPUFreqIndicator = class CPUFreqIndicator extends baseindicator.CPUFreqBaseI
 
     _updateUi() {
         this.imMinLabel.set_text(this._getMinText());
-        this.minSlider.setValue(this.minVal / 100.0);
+        this.minSlider.value = this.minVal / 100.0;
 
         this.imMaxLabel.set_text(this._getMaxText());
-        this.maxSlider.setValue(this.maxVal / 100.0);
+        this.maxSlider.value = this.maxVal / 100.0;
 
         this.imTurboSwitch.setToggleState(this.isTurboBoostActive);
         for (let p of this.profiles) {


### PR DESCRIPTION
I have been annoyed by issue #88 for a few days now. But after some digging, I've found a quick and easy fix. Since [this upstream commit](https://github.com/GNOME/gnome-shell/commit/b970ee72936ec884cd737829b1229664c1104463), the `setValue()` method is no longer valid. They didn't even try to think about backwards compactibility. 

Anyway, this is the fix: just replace `setValue()` with `value = ...`.