### PR TITLE
Fixed Gnome Shell Warnings

### DIFF
--- a/src/baseindicator.js
+++ b/src/baseindicator.js
@@ -46,7 +46,7 @@ var CPUFreqBaseIndicator = class CPUFreqBaseIndicator {
     constructor() {
         this._mainButton = new PanelMenu.Button(null, 'cpupower');
         this.menu = this._mainButton.menu;
-        this.actor = this._mainButton.actor;
+        this.actor = this._mainButton;
 
         this.settings = Convenience.getSettings(SETTINGS_ID);
 

--- a/src/indicator.js
+++ b/src/indicator.js
@@ -196,7 +196,7 @@ var CPUFreqIndicator = class CPUFreqIndicator extends baseindicator.CPUFreqBaseI
             this.imMinLabel.set_text(this._getMinText());
             this._updateMin();
         });
-        this.imSliderMin.actor.add(this.minSlider.actor, {expand: true});
+        this.imSliderMin.add(this.minSlider, {expand: true});
 
         this.imSliderMax = new PopupMenu.PopupBaseMenuItem({activate: false});
         this.maxSlider = new Slider.Slider(this.maxVal / 100);
@@ -205,7 +205,7 @@ var CPUFreqIndicator = class CPUFreqIndicator extends baseindicator.CPUFreqBaseI
             this.imMaxLabel.set_text(this._getMaxText());
             this._updateMax();
         });
-        this.imSliderMax.actor.add(this.maxSlider.actor, {expand: true});
+        this.imSliderMax.add(this.maxSlider, {expand: true});
 
         this.imCurrentTitle = new PopupMenu.PopupMenuItem(_('Current Frequency:'), {reactive:false});
         this.imCurrentLabel = new St.Label({text: this._getCurFreq()});

--- a/src/indicator.js
+++ b/src/indicator.js
@@ -293,7 +293,7 @@ var CPUFreqIndicator = class CPUFreqIndicator extends baseindicator.CPUFreqBaseI
     }
 
     _updateAutoSwitch() {
-        this.powerActions(this._power_state);
+        if (this._power_state) this.powerActions(this._power_state);
         this._updateFile();
     }
 


### PR DESCRIPTION
These commits are technically fixing #64 but the fix for the "object.actor is deprecated" warnings are very experimental. But it works and I found no issues.

Here my thoughts about that:
According to the [GNOME Wiki](https://wiki.gnome.org/Projects/GnomeShell/Extensions/StepByStepTutorial#knowingClutter) every UI-object is an actor ... so (Gjs-)UI-objects are subclasses of `Clutter.Actor` right? So you basically don't need the property `actor` because if somebody needs the `Actor` of an object, you could pass the object itself, couldn't you?? This is highly speculative but replacing every `object.actor` with just `object` works .... so what do you think?