### PR TITLE
Gnome 3.36 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
 	"localedir":"/usr/local/share/locale",
 	"shell-version": [
-		"3.26", "3.28", "3.30", "3.32", "3.34"
+		"3.26", "3.28", "3.30", "3.32", "3.34", "3.35"
 	],
 	"uuid": "cpupower@mko-sl.de",
 	"name": "CPU Power Manager",

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
 	"localedir":"/usr/local/share/locale",
 	"shell-version": [
-		"3.26", "3.28", "3.30", "3.32", "3.34", "3.35"
+		"3.26", "3.28", "3.30", "3.32", "3.34", "3.35", "3.36"
 	],
 	"uuid": "cpupower@mko-sl.de",
 	"name": "CPU Power Manager",

--- a/src/baseindicator.js
+++ b/src/baseindicator.js
@@ -46,7 +46,7 @@ var CPUFreqBaseIndicator = class CPUFreqBaseIndicator {
     constructor() {
         this._mainButton = new PanelMenu.Button(null, 'cpupower');
         this.menu = this._mainButton.menu;
-        this.actor = this._mainButton.actor;
+        this.actor = this._mainButton;
 
         this.settings = Convenience.getSettings(SETTINGS_ID);
 

--- a/src/indicator.js
+++ b/src/indicator.js
@@ -196,7 +196,7 @@ var CPUFreqIndicator = class CPUFreqIndicator extends baseindicator.CPUFreqBaseI
             this.imMinLabel.set_text(this._getMinText());
             this._updateMin();
         });
-        this.imSliderMin.actor.add(this.minSlider.actor, {expand: true});
+        this.imSliderMin.add(this.minSlider, {expand: true});
 
         this.imSliderMax = new PopupMenu.PopupBaseMenuItem({activate: false});
         this.maxSlider = new Slider.Slider(this.maxVal / 100);
@@ -205,7 +205,7 @@ var CPUFreqIndicator = class CPUFreqIndicator extends baseindicator.CPUFreqBaseI
             this.imMaxLabel.set_text(this._getMaxText());
             this._updateMax();
         });
-        this.imSliderMax.actor.add(this.maxSlider.actor, {expand: true});
+        this.imSliderMax.add(this.maxSlider, {expand: true});
 
         this.imCurrentTitle = new PopupMenu.PopupMenuItem(_('Current Frequency:'), {reactive:false});
         this.imCurrentLabel = new St.Label({text: this._getCurFreq()});
@@ -293,7 +293,7 @@ var CPUFreqIndicator = class CPUFreqIndicator extends baseindicator.CPUFreqBaseI
     }
 
     _updateAutoSwitch() {
-        this.powerActions(this._power_state);
+        if (this._power_state) this.powerActions(this._power_state);
         this._updateFile();
     }
 

--- a/src/indicator.js
+++ b/src/indicator.js
@@ -191,7 +191,7 @@ var CPUFreqIndicator = class CPUFreqIndicator extends baseindicator.CPUFreqBaseI
 
         this.imSliderMin = new PopupMenu.PopupBaseMenuItem({activate: false});
         this.minSlider = new Slider.Slider(this.minVal / 100);
-        this.minSlider.connect(Config.PACKAGE_VERSION.startsWith('3.34') ? 'notify::value' : 'value-changed', item => {
+        this.minSlider.connect(parseFloat(Config.PACKAGE_VERSION.substring(0,4))>=3.34 ? 'notify::value' : 'value-changed', item => {
             this.minVal = Math.floor(item.value * 100);
             this.imMinLabel.set_text(this._getMinText());
             this._updateMin();
@@ -200,7 +200,7 @@ var CPUFreqIndicator = class CPUFreqIndicator extends baseindicator.CPUFreqBaseI
 
         this.imSliderMax = new PopupMenu.PopupBaseMenuItem({activate: false});
         this.maxSlider = new Slider.Slider(this.maxVal / 100);
-        this.maxSlider.connect(Config.PACKAGE_VERSION.startsWith('3.34') ? 'notify::value' : 'value-changed', item => {
+        this.maxSlider.connect(parseFloat(Config.PACKAGE_VERSION.substring(0,4))>=3.34 ? 'notify::value' : 'value-changed', item => {
             this.maxVal = Math.floor(item.value * 100);
             this.imMaxLabel.set_text(this._getMaxText());
             this._updateMax();
@@ -299,12 +299,12 @@ var CPUFreqIndicator = class CPUFreqIndicator extends baseindicator.CPUFreqBaseI
 
     _updateUi() {
         this.imMinLabel.set_text(this._getMinText());
-        Config.PACKAGE_VERSION.startsWith('3.34')
+        parseFloat(Config.PACKAGE_VERSION.substring(0,4))>=3.34
             ? this.minSlider.value = this.minVal / 100.0
             : this.minSlider.setValue(this.minVal / 100.0);
 
         this.imMaxLabel.set_text(this._getMaxText());
-        Config.PACKAGE_VERSION.startsWith('3.34')
+        parseFloat(Config.PACKAGE_VERSION.substring(0,4))>=3.34
             ? this.maxSlider.value = this.maxVal / 100.0
             : this.maxSlider.setValue(this.maxVal / 100.0);
 

--- a/src/profilebutton.js
+++ b/src/profilebutton.js
@@ -29,12 +29,13 @@ const Lang = imports.lang;
 const PanelMenu = imports.ui.panelMenu;
 const Panel = imports.ui.panel;
 const PopupMenu = imports.ui.popupMenu;
+const GObject = imports.gi.GObject;
 
 const DEFAULT_EMPTY_NAME = 'No name';
 
-var CPUFreqProfileButton = class CPUFreqProfileButton extends PopupMenu.PopupMenuItem {
-    constructor(profile) {
-        super(_(profile.Name || DEFAULT_EMPTY_NAME), { reactive:true });
-        this.Profile = profile;
-    }
-}
+var CPUFreqProfileButton = GObject.registerClass(class CPUFreqProfileButton extends PopupMenu.PopupMenuItem {
+    _init(profile) {
+		super._init(_(profile.Name || DEFAULT_EMPTY_NAME), { reactive:true });
+    	this.Profile = profile;
+	}
+});


### PR DESCRIPTION
Added support for Gnome Shell 3.36 (Ubuntu 20.04), a patch for #99.

I have secretly merged the warnings fix (#100) into this branch for #64, because I think for a "support new version"-patch we should get rid of the 'deprecated'-warnings. I tested #100 for a few weeks now on my daily driver and everything works fine.

### Test
Finally, the gnome-shell 3.36.0 package is available in the Ubuntu repositories and I could fully test the extension on Ubuntu 20.04. I found no further issues.
Its also running flawlessly on Arch Linux with Gnome Shell 3.36.0.