### PR TITLE
Use more compact unicode characters for GHz/MHz

### DIFF
--- a/src/indicator.js
+++ b/src/indicator.js
@@ -393,9 +393,9 @@ var CPUFreqIndicator = class CPUFreqIndicator extends baseindicator.CPUFreqBaseI
 
     _getCurFreq() {
         if(this.lblUnit)
-            return (this.cpufreq.toString() / 1000).toFixed(2) + 'GHz';
+            return (this.cpufreq.toString() / 1000).toFixed(2) + '㎓';
         else
-            return this.cpufreq.toString() + 'MHz';
+            return this.cpufreq.toString() + '㎒';
     }
 
     _onPreferencesActivate(item) {


### PR DESCRIPTION
This PR replace GHz with ㎓ unicode character, so the extension take less space in top bar.