### PR TITLE
cpufreqctl: avoid boosting when measuring pstate frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/deinstapel/cpupower/releases">
     <img alt="Lastest release" src="https://img.shields.io/github/v/release/deinstapel/cpupower?label=latest%20release&sort=semver">
   </a>
-  <img alt="Gnome 42" src="https://img.shields.io/badge/gnome-42-blue?logo=gnome&logoColor=white">
+  <img alt="Gnome 43" src="https://img.shields.io/badge/gnome-43-blue?logo=gnome&logoColor=white">
   <a href="https://github.com/deinstapel/cpupower/blob/master/LICENSE">
     <img alt="License" src="https://img.shields.io/github/license/deinstapel/cpupower.svg">
   </a>

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
 	"localedir": "/usr/local/share/locale",
 	"shell-version": [
-		  "3.28", "3.30", "3.36", "3.38", "40", "41", "42"
+		  "3.28", "3.30", "3.36", "3.38", "40", "41", "42", "43"
 	],
 	"uuid": "cpupower@mko-sl.de",
 	"name": "CPU Power Manager",

--- a/src/indicator.js
+++ b/src/indicator.js
@@ -108,7 +108,7 @@ var CPUFreqIndicator = class CPUFreqIndicator extends baseindicator.CPUFreqBaseI
     }
 
     enable() {
-        this.power = Main.panel.statusArea["aggregateMenu"]._power;
+        this.power = imports.ui.main.panel.statusArea.quickSettings._system._systemItem._powerToggle;
         this.powerState = this.power._proxy.State;
         this.powerConnectSignalId = this.power._proxy.connect(
             "g-properties-changed",

--- a/src/indicator.js
+++ b/src/indicator.js
@@ -108,7 +108,12 @@ var CPUFreqIndicator = class CPUFreqIndicator extends baseindicator.CPUFreqBaseI
     }
 
     enable() {
-        this.power = imports.ui.main.panel.statusArea.quickSettings._system._systemItem._powerToggle;
+        if (parseFloat(Config.PACKAGE_VERSION.substring(0, 4)) >= 43) {
+            this.power = imports.ui.main.panel.statusArea.quickSettings._system._systemItem._powerToggle;
+        } else {
+            this.power = Main.panel.statusArea["aggregateMenu"]._power;
+        }
+
         this.powerState = this.power._proxy.State;
         this.powerConnectSignalId = this.power._proxy.connect(
             "g-properties-changed",

--- a/tool/cpufreqctl
+++ b/tool/cpufreqctl
@@ -22,6 +22,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set -o errexit -o nounset
+renice -n 19 0 >/dev/null
 
 VERSION="10.1.2"
 PRODUCTION=yes
@@ -91,6 +92,29 @@ not_supported ()
 {
     log "error: the backend '$1' is not supported on your system!"
     EXIT_CODE=9
+}
+
+# echo min/max/avg/rnd of a space-separated list of numbers
+compute_min_max_avg_rnd ()
+{
+    measures=($1)
+    nb_measures=${#measures[@]}
+    max=0
+    min=${measures[0]}
+    tot=0
+    for i in "${measures[@]}"; do
+        tot=$(($tot + $i))
+        if [ "$i" -gt "$max" ]; then
+            max=$i
+        fi
+        if [ "$i" -lt "$min" ]; then
+            min=$i
+        fi
+    done
+    avg=$(($tot/$nb_measures))
+    rnd_id=$(($RANDOM % $nb_measures))
+    rnd=${measures[$rnd_id]}
+    echo --min "${min}" --max "${max}" --avg "${avg}" --rnd "${rnd}"
 }
 
 fake_init ()
@@ -175,24 +199,8 @@ fake_info_frequencies ()
 fake_info_current ()
 {
     fake_init
-
-    shuf -i 800000-3600000 -n 12 | sort -n | awk '
-        BEGIN {
-            srand()
-        }
-        NR == 1 {
-            printf "%d ", $1
-        }
-        {
-            sum += $1
-            r[NR] = $1
-        }
-        END {
-            printf "%d %.0f %d\n", $1, sum / NR, r[int(rand() * NR) + 1]
-        }' | while read -r min max avg rnd
-    do
-        report_info_current --min "${min}" --max "${max}" --avg "${avg}" --rnd "${rnd}"
-    done
+    measures=$(shuf -i 800000-3600000 -n 12)
+    report_info_current $(compute_min_max_avg_rnd "$measures")
 }
 
 intel_pstate_supported ()
@@ -276,27 +284,8 @@ intel_pstate_info_frequencies ()
 
 intel_pstate_info_current ()
 {
-    sleep 0.01
-    for scaling_cur_freq in /sys/devices/system/cpu/cpufreq/policy*/scaling_cur_freq
-    do
-        cat "${scaling_cur_freq}" &
-    done | sort -n | awk '
-        BEGIN {
-            srand()
-        }
-        NR == 1 {
-            printf "%d ", $1
-        }
-        {
-            sum += $1
-            r[NR] = $1
-        }
-        END {
-            printf "%d %.0f %d\n", $1, sum / NR, r[int(rand() * NR) + 1]
-        }' | while read -r min max avg rnd
-    do
-        report_info_current --min "${min}" --max "${max}" --avg "${avg}" --rnd "${rnd}"
-    done
+    measures=$(cat /sys/devices/system/cpu/cpufreq/policy*/scaling_cur_freq)
+    report_info_current $(compute_min_max_avg_rnd "$measures")
 }
 
 cpufreq_supported ()
@@ -473,26 +462,8 @@ cpufreq_info_frequencies ()
 
 cpufreq_info_current ()
 {
-    for scaling_cur_freq in /sys/devices/system/cpu/cpufreq/policy*/scaling_cur_freq
-    do
-        cat "${scaling_cur_freq}" &
-    done | sort -n | awk '
-        BEGIN {
-            srand()
-        }
-        NR == 1 {
-            printf "%d ", $1
-        }
-        {
-            sum += $1
-            r[NR] = $1
-        }
-        END {
-            printf "%d %.0f %d\n", $1, sum / NR, r[int(rand() * NR) + 1]
-        }' | while read -r min max avg rnd
-    do
-        report_info_current --min "${min}" --max "${max}" --avg "${avg}" --rnd "${rnd}"
-    done
+    measures=$(cat /sys/devices/system/cpu/cpufreq/policy*/scaling_cur_freq)
+    report_info_current $(compute_min_max_avg_rnd "$measures")
 }
 
 backend_select()

--- a/tool/cpufreqctl
+++ b/tool/cpufreqctl
@@ -276,6 +276,7 @@ intel_pstate_info_frequencies ()
 
 intel_pstate_info_current ()
 {
+    sleep 0.01
     for scaling_cur_freq in /sys/devices/system/cpu/cpufreq/policy*/scaling_cur_freq
     do
         cat "${scaling_cur_freq}" &

--- a/tool/cpufreqctl
+++ b/tool/cpufreqctl
@@ -95,25 +95,32 @@ not_supported ()
 }
 
 # echo min/max/avg/rnd of a space-separated list of numbers
+# $1 number of element
+# $2 space-separated list of numbers
 compute_min_max_avg_rnd ()
 {
-    measures=($1)
-    nb_measures=${#measures[@]}
+    nb_measures=$1
+    measures=$2
     max=0
-    min=${measures[0]}
+    min=10000000
     tot=0
-    for i in "${measures[@]}"; do
-        tot=$(($tot + $i))
+    idx=0
+    rnd_id=$(shuf -i 0-$((nb_measures-1)) -n 1)
+    for i in $measures; do
+        tot=$((tot + i))
         if [ "$i" -gt "$max" ]; then
             max=$i
         fi
         if [ "$i" -lt "$min" ]; then
             min=$i
         fi
+        if [ "$idx" -eq "$rnd_id" ]; then
+            rnd=$i
+        fi
+        idx=$((idx+1))
     done
-    avg=$(($tot/$nb_measures))
-    rnd_id=$(($RANDOM % $nb_measures))
-    rnd=${measures[$rnd_id]}
+    avg=$((tot/nb_measures))
+
     echo --min "${min}" --max "${max}" --avg "${avg}" --rnd "${rnd}"
 }
 
@@ -200,7 +207,8 @@ fake_info_current ()
 {
     fake_init
     measures=$(shuf -i 800000-3600000 -n 12)
-    report_info_current $(compute_min_max_avg_rnd "$measures")
+    num_cores=12
+    report_info_current $(compute_min_max_avg_rnd "$num_cores" "$measures")
 }
 
 intel_pstate_supported ()
@@ -285,7 +293,8 @@ intel_pstate_info_frequencies ()
 intel_pstate_info_current ()
 {
     measures=$(cat /sys/devices/system/cpu/cpufreq/policy*/scaling_cur_freq)
-    report_info_current $(compute_min_max_avg_rnd "$measures")
+    num_cores=$(getconf _NPROCESSORS_ONLN)
+    report_info_current $(compute_min_max_avg_rnd "$num_cores" "$measures")
 }
 
 cpufreq_supported ()
@@ -463,7 +472,8 @@ cpufreq_info_frequencies ()
 cpufreq_info_current ()
 {
     measures=$(cat /sys/devices/system/cpu/cpufreq/policy*/scaling_cur_freq)
-    report_info_current $(compute_min_max_avg_rnd "$measures")
+    num_cores=$(getconf _NPROCESSORS_ONLN)
+    report_info_current $(compute_min_max_avg_rnd "$num_cores" "$measures")
 }
 
 backend_select()


### PR DESCRIPTION
Insert a `sleep` to avoid artificial high CPU frequency (boosting) when using `cpufreqctl info current` on a i7-1065G7 (Lenovo Yoga C940)